### PR TITLE
add json serializer parameters to put/patch/post. update packages

### DIFF
--- a/src/RiskFirst.RestClient/RestRequestExtensions.cs
+++ b/src/RiskFirst.RestClient/RestRequestExtensions.cs
@@ -89,10 +89,10 @@ namespace RiskFirst.RestClient
         /// </summary>
         /// <param name="request">The rest request</param>
         /// <returns>HttpResponseMessage</returns>
-        public static async Task<HttpResponseMessage> PostJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<HttpResponseMessage> PostJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken), JsonSerializerSettings settings = null)
         {
             var content = new StringContent(
-                    JsonConvert.SerializeObject(body), System.Text.Encoding.UTF8, "application/json");
+                    JsonConvert.SerializeObject(body, settings), System.Text.Encoding.UTF8, "application/json");
 
             try
             {
@@ -111,10 +111,10 @@ namespace RiskFirst.RestClient
         /// </summary>
         /// <param name="request">The rest request</param>
         /// <returns>HttpResponseMessage</returns>
-        public static async Task<HttpResponseMessage> PutJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<HttpResponseMessage> PutJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken), JsonSerializerSettings settings = null)
         {
             var content = new StringContent(
-                    JsonConvert.SerializeObject(body), System.Text.Encoding.UTF8, "application/json");
+                    JsonConvert.SerializeObject(body, settings), System.Text.Encoding.UTF8, "application/json");
 
             try
             {
@@ -133,10 +133,10 @@ namespace RiskFirst.RestClient
         /// </summary>
         /// <param name="request">The rest request</param>
         /// <returns>HttpResponseMessage</returns>
-        public static async Task<HttpResponseMessage> PatchJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<HttpResponseMessage> PatchJsonAsync<T>(this RestRequest request, T body, HttpClient httpClient = null, CancellationToken cancellationToken = default(CancellationToken), JsonSerializerSettings settings = null)
         {
             var content = new StringContent(
-                    JsonConvert.SerializeObject(body), System.Text.Encoding.UTF8, "application/json");
+                    JsonConvert.SerializeObject(body, settings), System.Text.Encoding.UTF8, "application/json");
 
             try
             {

--- a/src/RiskFirst.RestClient/RiskFirst.RestClient.csproj
+++ b/src/RiskFirst.RestClient/RiskFirst.RestClient.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/riskfirst/riskfirst.restclient</RepositoryUrl>
     <RepositoryType>GIT</RepositoryType>
     <PackageTags>rest http dotnetcore</PackageTags>
-    <Version>1.0.6</Version>
+    <Version>1.1.0</Version>
     <PackageReleaseNotes>
       v0.0.1 - Initial release
       v0.0.2 - Changed usage of HttpClient, normalised With* methods.
@@ -21,17 +21,18 @@
       v1.0.3 - Added more support for headers
       v1.0.4 - Added support for multiple values for a given query parameter
       v1.0.5 - Downgraded targetting to netstandard1.1;net45
-      v1.0.6 - Added Additional extension methods to support non JSON requests</PackageReleaseNotes>
-    <AssemblyVersion>1.0.6.0</AssemblyVersion>
-    <FileVersion>1.0.6.0</FileVersion>
+      v1.0.6 - Added Additional extension methods to support non JSON requests
+      v1.1.0 - Add json serializer settings to put/patch/post operations. Upgrade package dependencies</PackageReleaseNotes>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>RiskFirst.RestClient.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="newtonsoft.json" Version="10.0.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/RiskFirst.RestClient.Tests/RestRequestTests.cs
+++ b/tests/RiskFirst.RestClient.Tests/RestRequestTests.cs
@@ -21,7 +21,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithPathSegment("api")
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api", req.RequestUri.ToString());            
+            Assert.Equal($"{RootUri}/api", req.RequestUri.ToString());            
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithPathSegment("api")
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithPathSegment("entity")
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api/entity", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api/entity", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithPathSegments("api","entity",123)
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api/entity/123", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api/entity/123", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithPathSegments(new List<string> { "api", "entity", "123" })
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api/entity/123", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api/entity/123", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameter("foo","bar")
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameter("foo", "bar", "zoo")
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=bar&foo=zoo", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=bar&foo=zoo", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameter("foo", new[] { "bar", "zoo" })
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=bar&foo=zoo", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=bar&foo=zoo", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameter("foo", null)
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameters(new { foo = "bar" })
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace RiskFirst.RestClient.Tests
                             .WithQueryParameters(new Dictionary<string, object>() { { "foo", "bar" } })
                             .CreateRequestMessage(HttpMethod.Get);
 
-            Assert.StrictEqual($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
+            Assert.Equal($"{RootUri}/api?foo=bar", req.RequestUri.ToString());
         }
 
         [Fact]

--- a/tests/RiskFirst.RestClient.Tests/RiskFirst.RestClient.Tests.csproj
+++ b/tests/RiskFirst.RestClient.Tests/RiskFirst.RestClient.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="moq" Version="4.7.10" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="moq" Version="4.7.145" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
only non self explanatory change is removing the use of strictequals in the unit tests - this is following code insight warning this shouldn't be used for strings.